### PR TITLE
fix Safari 2x .btn-clicked form/data issue

### DIFF
--- a/src/Assignments/ProblemIframe.tsx
+++ b/src/Assignments/ProblemIframe.tsx
@@ -82,7 +82,7 @@ export const ProblemIframe: React.FC<ProblemIframeProps> = ({problem, setProblem
                 console.error('Could not find the button that submitted the form');
                 return;
             }
-            formData.append(clickedButton.name, clickedButton.value);
+            formData.set(clickedButton.name, clickedButton.value);
             const submiturl = problemForm.getAttribute('action');
             if(_.isNil(submiturl)) {
                 setError('An error occurred');


### PR DESCRIPTION
use FormData.set instead of .append -- this avoids different behavior between browsers... apparently Safari picks up on the clicked button already, while Chrome doesn't.