### PR TITLE
RED-122 Quick fix for dead date null

### DIFF
--- a/src/Courses/Settings/OverridesForm.tsx
+++ b/src/Courses/Settings/OverridesForm.tsx
@@ -169,7 +169,7 @@ export const OverridesForm: React.FC<OverridesFormProps> = ({topic, userId, prob
                 extensions: {
                     startDate: inputs.startDate,
                     endDate: inputs.endDate,
-                    deadDate: inputs.deadDate,
+                    deadDate: inputs.deadDate ?? inputs.endDate,
                 },
                 studentTopicAssessmentOverride: {
                     duration: inputs.duration,


### PR DESCRIPTION
All overrides can be nullable but currently the UI is setup in such a
way that they cannot

This caused bugs on exams where dead date is null

If dead date is null default to end date