### PR TITLE
Replaced embed with img tag to handle images.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "scripts": {
     "start": "PORT=3002 react-scripts start",
+    "start-https": "PORT=3002 HTTPS=true react-scripts start",
     "server": "npm run start:watch --prefix ../backend/",
     "renderer": "(cd ../renderer && sudo morbo ./script/render_app)",
     "renderer-docker": "(cd ../renderer-docker && ./start_docker.sh)",

--- a/src/Courses/TopicGrades/PrintEverything.tsx
+++ b/src/Courses/TopicGrades/PrintEverything.tsx
@@ -85,13 +85,23 @@ export const PrintEverything: React.FC<PrintEverythingProps> = () => {
                             }
 
                             return (
-                                <embed
+                                <img
                                     key={cloudFilename}
-                                    title={cloudFilename}
+                                    alt={cloudFilename}
                                     src={cloudUrl}
                                     style={{maxWidth: '100%'}}
                                 />
                             );
+
+                            /* We currently only support images and PDFs. */
+                            // return (
+                            //     <embed
+                            //         key={cloudFilename}
+                            //         title={cloudFilename}
+                            //         src={cloudUrl}
+                            //         style={{maxWidth: '100%'}}
+                            //     />
+                            // );
                         })
                         }
                     </div>

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -10,4 +10,13 @@ module.exports =  function(app) {
     app.use(createProxyMiddleware('/webwork2_files', {
         target: 'http://localhost:3000'
     }));
+
+    /* If you're hosting attachments in an S3 bucket, point this proxy to that bucket.
+       You may need to use `npm run start-https` and secure: true in the config
+       object below if you get SSL errors. */
+    // app.use(createProxyMiddleware('/work', {
+    //     target: '',
+    //     changeOrigin: true,
+    //     secure: true,
+    // }));
 };


### PR DESCRIPTION
This fixes problems on Chrome where images weren't taking up the full space available for them, and not scaling correctly when the embed was set to take up a full width.

This also includes some notes about setting up proxies to S3 buckets and HTTPS errors.