### PR TITLE
Fixed bug where clicking a student from the Problems level of the Gra…

### DIFF
--- a/src/Courses/CourseDetailsTabs/GradesTab.tsx
+++ b/src/Courses/CourseDetailsTabs/GradesTab.tsx
@@ -87,7 +87,9 @@ export const GradesTab: React.FC<GradesTabProps> = ({course, setStudentGradesTab
             const gradesArr: Array<any> = res.data.data || [];
 
             const flatGradesArr = _.map(gradesArr, grade => {
-                const mergedGrade = {...grade.user, ...grade};
+                // This order causes the id field from the user to take precedence.
+                // One will have to be renamed when implementing URL querystrings for the Student's Grades view link.
+                const mergedGrade = {...grade, ...grade.user};
                 delete mergedGrade.user;
                 return mergedGrade;
             });


### PR DESCRIPTION
…des tab would cause that Student's Grade view to break.

The id of the problem was overwriting the id of the student, so this commit reorders them so the student id always takes precedence.

This may have to change when we introduce URL routing for the sub-tab navigation.