### PR TITLE
Replaced history.push with history.replace.

### DIFF
--- a/src/Courses/TopicGrades/GradingPage.tsx
+++ b/src/Courses/TopicGrades/GradingPage.tsx
@@ -48,7 +48,7 @@ export const TopicGradingPage: React.FC<TopicGradingPageProps> = () => {
             userId: selected?.user?.id ?? queryParams.get('userId'),
         }).omitBy(_.isNil).value() as any).toString();
 
-        history.push(`${url}?${queryString}`);
+        history.replace(`${url}?${queryString}`);
     }, [selected]);
 
     useEffect(() => {


### PR DESCRIPTION
This fixes weird navigation on the Grading page, since we really only care about the query parameters when navigating to or away from the page.