### PR TITLE
RED-486 Fixed bug that blocked email until page refresh

### DIFF
--- a/src/Courses/CourseDetailsTabs/EmailModal.tsx
+++ b/src/Courses/CourseDetailsTabs/EmailModal.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, { useState } from 'react';
-import { Modal, ModalTitle, ModalBody, Form, Button, ModalFooter, FormGroup, FormControl, FormLabel, Alert } from 'react-bootstrap';
+import { Modal, ModalTitle, ModalBody, Form, Button, ModalFooter, FormGroup, FormControl, FormLabel, Alert, Spinner } from 'react-bootstrap';
 import ModalHeader from 'react-bootstrap/ModalHeader';
 import AxiosRequest from '../../Hooks/AxiosRequest';
 import useAlertState from '../../Hooks/useAlertState';
@@ -12,24 +12,44 @@ interface EmailModalProps {
     setClose: () => void;
 }
 
+enum EmailModalState {
+    READY='READY',
+    SENDING='SENDING',
+    COMPLETE='COMPLETE'
+}
 /**
  * This modal pops up with a form to email students.
  * The users that are emailed are chosen on another screen.
  */
-export const EmailModal: React.FC<EmailModalProps> = ({users, show, setClose}) => {
+export const EmailModal: React.FC<EmailModalProps> = ({users, show, setClose: setCloseProp}) => {
     const [subject, setSubject] = useState('');
     const [body, setBody] = useState('');
     const [{message: sendEmailRespMsg, variant: sendEmailRespAlertType}, setSendEmailRespMsg] = useAlertState();
+    const [modalState, setModalState] = useState(EmailModalState.READY);
 
     const onSendEmail = async () => {
         try {
+            setModalState(EmailModalState.SENDING);
             const res = await AxiosRequest.post('/users/email', {subject, content: body, userIds: _.map(users, 'id')});
             const msg = res.data?.data?.msg || 'Success';
             setSendEmailRespMsg({message: msg, variant: 'success'});
+            setModalState(EmailModalState.COMPLETE);
         } catch (e) {
             const msg = e?.data?.data?.msg || 'An error occurred';
             setSendEmailRespMsg({message: msg, variant: 'danger'});
+            setModalState(EmailModalState.READY);
         }
+    };
+
+    const setClose = () => {
+        setCloseProp();
+        setSubject('');
+        setBody('');
+        setSendEmailRespMsg({
+            message: '',
+            variant: 'info'
+        });
+        setModalState(EmailModalState.READY);
     };
 
     return (
@@ -37,37 +57,49 @@ export const EmailModal: React.FC<EmailModalProps> = ({users, show, setClose}) =
             <ModalHeader closeButton>
                 <ModalTitle>Email Students</ModalTitle>
             </ModalHeader>
-            <ModalBody>
-                <Form>
-                    <Alert variant={sendEmailRespAlertType} show={Boolean(sendEmailRespMsg)}>{sendEmailRespMsg}</Alert>
-                    <div>You are sending an email to {users.length} students.</div>
-                    <FormGroup controlId='Subject'>
-                        <FormLabel>Subject: </FormLabel>
-                        <FormControl
-                            type='text'
-                            autoComplete='off'
-                            onChange={(e: any) => setSubject(e.target.value)}
-                        />
-                    </FormGroup>
-                    <FormGroup>
-                        <FormLabel>Message Content:</FormLabel>
-                        <FormControl
-                            as='textarea'
-                            size='sm' style={{height: '200px'}}
-                            autoComplete='off'
-                            onChange={(e: any) => setBody(e.target.value)}
-                        />
-                    </FormGroup>
-                </Form>
-            </ModalBody>
-            <ModalFooter>
-                <Button
-                    variant="primary"
-                    onClick={onSendEmail}
-                    disabled={sendEmailRespAlertType === 'success'}
-                >
-                        Send Email</Button>
-            </ModalFooter>
+            <Form>
+                <fieldset disabled={modalState !== EmailModalState.READY}>
+                    <ModalBody>
+                        {modalState === EmailModalState.SENDING &&
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    width:'100%',
+                                    padding: '10px',
+                                }}
+                            >
+                                <Spinner animation='border' role='status' style={{margin:'auto'}}><span className='sr-only'>Loading...</span></Spinner>
+                            </div>
+                        }
+                        <Alert variant={sendEmailRespAlertType} show={Boolean(sendEmailRespMsg)}>{sendEmailRespMsg}</Alert>
+                        <div>You are sending an email to {users.length} students.</div>
+                        <FormGroup controlId='Subject'>
+                            <FormLabel>Subject: </FormLabel>
+                            <FormControl
+                                type='text'
+                                autoComplete='off'
+                                onChange={(e: any) => setSubject(e.target.value)}
+                            />
+                        </FormGroup>
+                        <FormGroup>
+                            <FormLabel>Message Content:</FormLabel>
+                            <FormControl
+                                as='textarea'
+                                size='sm' style={{height: '200px'}}
+                                autoComplete='off'
+                                onChange={(e: any) => setBody(e.target.value)}
+                            />
+                        </FormGroup>
+                    </ModalBody>
+                    <ModalFooter>
+                        <Button
+                            variant="primary"
+                            onClick={onSendEmail}
+                        >
+                                Send Email</Button>
+                    </ModalFooter>
+                </fieldset>
+            </Form>
         </Modal>
     );
 };

--- a/src/Courses/CourseDetailsTabs/GradesTab.tsx
+++ b/src/Courses/CourseDetailsTabs/GradesTab.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Nav, Row } from 'react-bootstrap';
+import { Button, Nav } from 'react-bootstrap';
 import GradeTable from './GradeTable';
 import _ from 'lodash';
 import SubObjectDropdown from '../../Components/SubObjectDropdown';


### PR DESCRIPTION
Email students now clears all state before bowing out

With this I added a state machine to make it a little bit cleaner:
The entire form is only enabled when ready, not while loading or after
submission
A loading spinner shows while the email is sending

This prevents profs from accidentally making the requests multiple times
really quickly